### PR TITLE
Prometheusとnode_exporterを使ってプル型の内部監視を実現する

### DIFF
--- a/chapter2/occhi/Dockerfile
+++ b/chapter2/occhi/Dockerfile
@@ -1,0 +1,15 @@
+# Ruby 3.2のベースイメージを使用
+FROM ruby:3.2
+
+# Node Exporterのバージョンを指定
+ENV NODE_EXPORTER_VERSION=1.3.1
+
+# 必要なパッケージをインストール
+RUN apt-get update && apt-get install -y wget stress
+
+# Node Exporterをダウンロードしてインストール
+RUN wget https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
+    && tar xvfz node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
+    && mv node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64/node_exporter /usr/local/bin \
+    && rm -rf node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64
+

--- a/chapter2/occhi/README.md
+++ b/chapter2/occhi/README.md
@@ -1,19 +1,43 @@
 #  Prometheusで監視してみる
 ## 実際に負荷をかけてみる
-### Applicationサーバーの起動
-```bash
-$ ruby app_server/main.rb
-```
-Ref: https://github.com/sinatra/sinatra
-
-### prometheusを起動する
+### volumeの作成
 まずdocker volumeを作成します。
 ```bash
 $ docker volume create metrics_data
 ```
 
+### コンテナを起動する
+```bash
+$ docker compose up
+```
+
+### 負荷をかける
+target_appコンテナ内で以下のコマンドを実行する。
+4つのCPUコアに負荷をかける例だと、以下のようなコマンドを実行すれば良い。
+```bash
+# target_appコンテナのシェルを開く
+$ docker exec -it target_app bash
+
+# stressコマンドで負荷をかける
+$ stress -c 4
+```
+
 Ref: https://zenn.dev/aobaiwaki/articles/a612bf497c59ca
 
+### WIP: Applicationサーバーの起動
+(アプリケーションサーバーに負荷をかけたいが、コンテナ内だとruby main.rbでうまくいかない。)
+```bash
+$ ruby app_server/main.rb
+```
+Ref: https://github.com/sinatra/sinatra
+
+
+---
+
+## Prometheusで実行するクエリの例
+```
+avg without(cpu) (rate(node_cpu_seconds_total{mode!="idle"}[1m]))
+```
 
 ## Tips. 最小構成でPrometheus/node_exporterを起動する
 - どちらもdocker imageが公開されているので、そちらを利用することができます。

--- a/chapter2/occhi/README.md
+++ b/chapter2/occhi/README.md
@@ -1,0 +1,11 @@
+#  Prometheusで監視してみる
+## 最小構成でPrometheusを起動する
+- docker imageが公開されているので、そちらを利用することができます。
+
+```bash
+$ docker run \
+    -p 9090:9090 \
+    -v ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml \
+    prom/prometheus
+```
+Ref: https://hub.docker.com/r/prom/prometheus/

--- a/chapter2/occhi/README.md
+++ b/chapter2/occhi/README.md
@@ -1,7 +1,24 @@
 #  Prometheusで監視してみる
-## 最小構成でPrometheusを起動する
-- docker imageが公開されているので、そちらを利用することができます。
+## 実際に負荷をかけてみる
+### Applicationサーバーの起動
+```bash
+$ ruby app_server/main.rb
+```
+Ref: https://github.com/sinatra/sinatra
 
+### prometheusを起動する
+まずdocker volumeを作成します。
+```bash
+$ docker volume create metrics_data
+```
+
+Ref: https://zenn.dev/aobaiwaki/articles/a612bf497c59ca
+
+
+## Tips. 最小構成でPrometheus/node_exporterを起動する
+- どちらもdocker imageが公開されているので、そちらを利用することができます。
+
+### Prometheus
 ```bash
 $ docker run \
     -p 9090:9090 \
@@ -9,3 +26,15 @@ $ docker run \
     prom/prometheus
 ```
 Ref: https://hub.docker.com/r/prom/prometheus/
+
+### node_exporter
+```bash
+$ docker run -d \
+    --name node-exporter \
+    --net="host" \
+    --pid="host" \
+    -v "/:/host:ro,rslave" \
+    quay.io/prometheus/node-exporter:latest \
+    --path.rootfs=/host
+```
+Ref: https://github.com/prometheus/node_exporter

--- a/chapter2/occhi/app_server/main.rb
+++ b/chapter2/occhi/app_server/main.rb
@@ -1,0 +1,17 @@
+require 'bundler/inline'
+gemfile do
+  source 'https://rubygems.org'
+  gem 'sinatra'
+end
+
+get '/' do
+  'Hello world!'
+end
+
+get '/welcome' do
+  content_type :json
+  response = {
+    message: 'welcome to sinatra',
+  }
+  response.to_json
+end

--- a/chapter2/occhi/docker-compose.yml
+++ b/chapter2/occhi/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - metrics_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    ports:
+      - 9090:9090
+    restart: always
+
+volumes:
+  metrics_data:
+    external: true

--- a/chapter2/occhi/docker-compose.yml
+++ b/chapter2/occhi/docker-compose.yml
@@ -10,7 +10,20 @@ services:
     ports:
       - 9090:9090
     restart: always
-
+  target_app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: target_app
+    volumes:
+      - ./app_server:/app
+    ports:
+      - '3111:4567'
+      - '9100:9100'
+    tty: true
+    working_dir: /app
+    command: node_exporter
+    
 volumes:
   metrics_data:
     external: true

--- a/chapter2/occhi/prometheus/prometheus.yml
+++ b/chapter2/occhi/prometheus/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['localhost:9090']

--- a/chapter2/occhi/prometheus/prometheus.yml
+++ b/chapter2/occhi/prometheus/prometheus.yml
@@ -11,4 +11,4 @@ global:
 scrape_configs:
   - job_name: 'node'
     static_configs:
-      - targets: ['host.docker.internal:9100']
+      - targets: ['target_app:9100']

--- a/chapter2/occhi/prometheus/prometheus.yml
+++ b/chapter2/occhi/prometheus/prometheus.yml
@@ -9,11 +9,6 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'prometheus'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
-    scrape_interval: 5s
-
+  - job_name: 'node'
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['host.docker.internal:9100']


### PR DESCRIPTION
### Prometheusのクエリ
```
avg without(cpu) (rate(node_cpu_seconds_total{mode!="idle"}[1m]))
```

## 監視した結果
![スクリーンショット 2024-02-25 23 37 23](https://github.com/Progaku-copy/isucon-knowledge/assets/118090073/1d03b1c3-ca87-4f26-a5dc-64b32366a188)
